### PR TITLE
add list method with sorting

### DIFF
--- a/src/main/java/org/vaadin/artur/helpers/CrudService.java
+++ b/src/main/java/org/vaadin/artur/helpers/CrudService.java
@@ -1,12 +1,38 @@
 package org.vaadin.artur.helpers;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.vaadin.flow.data.provider.SortDirection;
+import com.vaadin.flow.data.provider.SortOrder;
+
 public abstract class CrudService<T, ID> {
+
+    public static class ListData<T> {
+        public List<T> data;
+        public int count;
+
+        public ListData(List<T> data, int count) {
+            this.data = data;
+            this.count = count;
+        }
+    }
+
+    public static class ListParams {
+        public static class ListOrder {
+            public String direction;
+            public String path;
+        }
+
+        public int page;
+        public int pageSize;
+        public List<ListOrder> sortOrders;
+    }
 
     protected abstract JpaRepository<T, ID> getRepository();
 
@@ -26,8 +52,21 @@ public abstract class CrudService<T, ID> {
         return getRepository().findAll(pageable);
     }
 
+    public ListData<T> list(ListParams params) {
+        ArrayList<SortOrder<String>> sorts = new ArrayList<>();
+        for (ListParams.ListOrder sort : params.sortOrders) {
+            sorts.add(new SortOrder<String>(sort.path,
+                    "asc".equals(sort.direction)
+                            ? SortDirection.ASCENDING
+                            : SortDirection.DESCENDING));
+        }
+        Pageable pageable = PagingUtil.offsetLimitSortOrdersToPageable(
+                params.page, params.pageSize, sorts);
+        return new ListData<T>(list(pageable).getContent(), count());
+    }
+
     public int count() {
-        return (int) getRepository().count();
+        return (int)getRepository().count();
     }
 
 }


### PR DESCRIPTION
It makes easier to use endpoints with grid dataProviders:

```
  async getGridData(params: any, callback: any) {
    const data = await CommandEndpoint.list(params);
    callback(data.data, data.count);
  }
```
