### PR TITLE
fix: use correct opened-changed event detail

### DIFF
--- a/src/main/resources/META-INF/resources/frontend/a-notification.ts
+++ b/src/main/resources/META-INF/resources/frontend/a-notification.ts
@@ -28,8 +28,8 @@ const _showNotification = (text: string, options: Options) => {
   n.appendChild(tpl);
   document.body.appendChild(n);
   n.opened = true;
-  n.addEventListener("opened-changed", (e: any) => {
-    if (!e.detail.opened) {
+  n.addEventListener("opened-changed", (e: CustomEvemt) => {
+    if (!e.detail.value) {
       document.body.removeChild(n);
     }
   });


### PR DESCRIPTION
The following error happens now and is apparently related to the helper.

```
1:04:07 PM: [ERROR] dules/.pnpm/@vaadin/vaadin-notification@20.0.0-alpha2/node_modules/@vaadin/vaadin-notification/src/interfaces").NotificationEventMap'.
1:04:07 PM: [ERROR]               Types of property ''opened-changed'' are incompatible.
1:04:07 PM: [ERROR]                 Type 'import("/opt/build/repo/frontend/demo/notification-helper").NotificationOpenedChanged' is not assignable to type 'import("/opt/build/repo/node_modules/.pnpm/@vaadin/vaadin-notification@20.0.0-alpha2/node_modules/@vaadin/vaadin-notification/src/interfaces").NotificationOpenedChanged'.
1:04:07 PM: [ERROR]                   Property 'value' is missing in type '{ opened: boolean; }' but required in type '{ value: boolean; }'.
1:04:07 PM: [ERROR]                     Type 'NotificationEventMap[K]' is not assignable to type 'Event & ProgressEvent<EventTarget> & ErrorEvent & UIEvent & AnimationEvent & MouseEvent & ... 9 more ... & NotificationOpenedChanged'.
```